### PR TITLE
Implement custom neutral losses (#8)

### DIFF
--- a/pepfrag/converters.h
+++ b/pepfrag/converters.h
@@ -13,7 +13,9 @@ std::vector<double> listToDoubleVector(PyObject* source);
 
 std::vector<std::string> listToStringVector(PyObject* source);
 
-std::vector<std::pair<IonType, std::vector<std::string>>> dictToIonTypeMap(PyObject* source);
+using IonTypeMap = std::vector<std::pair<IonType, std::vector<std::pair<std::string, double>>>>;
+
+IonTypeMap dictToIonTypeMap(PyObject* source);
 
 std::vector<ModMassSite> modSiteListToVector(PyObject* source, size_t seqLen);
 

--- a/pepfrag/cpepfrag.cpp
+++ b/pepfrag/cpepfrag.cpp
@@ -13,7 +13,7 @@ Ions generateIons(
 	IonType type,
 	const std::vector<double>& masses,
 	long charge,
-	const std::vector<std::string>& neutralLosses,
+	const std::vector<NeutralLossPair>& neutralLosses,
 	bool radical,
 	const std::string& sequence)
 {
@@ -31,7 +31,7 @@ PyObject* python_generateIons(PyObject* module, PyObject* args) {
 		if (!PyArg_ParseTuple(args, "OdOOOliO", &ionTypes, &precMass, &pySeqMasses, &bMassList,
 				      &yMassList, &charge, &radical, &pySequence)) return NULL;
 
-        std::vector< std::pair< IonType, std::vector< std::string > > > ionConfigs = dictToIonTypeMap(ionTypes);
+        IonTypeMap ionConfigs = dictToIonTypeMap(ionTypes);
 
         std::string sequence = PyUnicode_AsUTF8(pySequence);
 

--- a/pepfrag/iongenerator.cpp
+++ b/pepfrag/iongenerator.cpp
@@ -18,19 +18,19 @@ bool operator<(const Ion& left, const Ion& right)
 /* StringCache */
 
 class StringCache {
-        static std::unordered_map<long, std::string> cache;
+    static std::unordered_map<long, std::string> cache;
 
-        public:
+    public:
 
-                static std::string get(long n) {
-                        auto it = cache.find(n);
-                        if (it != cache.end()) {
-                                return it->second;
-                        }
-                        std::string entry = std::to_string(n);
-                        cache[n] = entry;
-                        return entry;
-                }
+        static std::string get(long n) {
+            auto it = cache.find(n);
+            if (it != cache.end()) {
+                return it->second;
+            }
+            std::string entry = std::to_string(n);
+            cache[n] = entry;
+            return entry;
+        }
 };
 
 std::unordered_map<long, std::string> StringCache::cache = std::unordered_map<long, std::string>();
@@ -62,7 +62,7 @@ IonGeneratorPtr IonGenerator::create(IonType type) {
 Ions IonGenerator::generate(
 	const std::vector<double>& masses,
 	long charge,
-	const std::vector<std::string>& neutralLosses,
+	const std::vector<NeutralLossPair>& neutralLosses,
 	bool radical,
 	const std::string& sequence) const
 {
@@ -113,9 +113,9 @@ void IonGenerator::generateNeutralLosses(
 	Ions& ions,
 	double mass,
 	long position,
-	const std::vector<std::string>& neutralLosses) const
+	const std::vector<NeutralLossPair>& neutralLosses) const
 {
-	for (const std::string& neutralLoss : neutralLosses) {
+	for (NeutralLossPair neutralLoss : neutralLosses) {
 		ions.push_back(generateNeutralLossIon(ionLabel, neutralLoss, mass, position));
 	}
 }
@@ -228,7 +228,7 @@ PrecursorIonGenerator::PrecursorIonGenerator() : IonGenerator("M") {}
 Ions PrecursorIonGenerator::generate(
 	const std::vector<double>& masses,
 	long charge,
-	const std::vector<std::string>& neutralLosses,
+	const std::vector<NeutralLossPair>& neutralLosses,
 	bool radical,
 	const std::string& sequence) const
 {
@@ -258,10 +258,10 @@ Ions PrecursorIonGenerator::generate(
 			);
 		}
 		
-		for (const std::string& neutralLoss : neutralLosses) {
+		for (NeutralLossPair neutralLoss : neutralLosses) {
 			ions.emplace_back(
-				(mass - FIXED_MASSES.at(neutralLoss)) / (double) cs + PROTON_MASS,
-				"[" + ionLabel + "-" + neutralLoss + "][" + chargeSymbol + "]",
+				(mass - neutralLoss.second) / (double) cs + PROTON_MASS,
+				"[" + ionLabel + "-" + neutralLoss.first + "][" + chargeSymbol + "]",
 				seqLen);
 		}
 	}
@@ -298,7 +298,7 @@ void PrecursorIonGenerator::generateNeutralLosses(
 	Ions& /*ions*/,
 	double /*mass*/,
 	long /*position*/,
-	const std::vector<std::string>& /*neutralLosses*/) const
+	const std::vector<NeutralLossPair>& /*neutralLosses*/) const
 {
 	// This method intentionally does nothing and should not be called
 	throw NotImplementedException();

--- a/pepfrag/iongenerator.h
+++ b/pepfrag/iongenerator.h
@@ -10,6 +10,8 @@
 
 #include "ion.h"
 
+using NeutralLossPair = std::pair<std::string, double>;
+
 const std::unordered_map<std::string, double> FIXED_MASSES = {
 	{"H", 1.007276466879},
 	{"tag", 304.20536},
@@ -50,7 +52,7 @@ class IonGenerator {
 		virtual Ions generate(
 			const std::vector<double>& masses,
 			long charge,
-			const std::vector<std::string>& neutralLosses,
+			const std::vector<NeutralLossPair>& neutralLosses,
 			bool radical,
 			const std::string& sequence) const;
 		
@@ -72,7 +74,7 @@ class IonGenerator {
 			Ions& ions,
 			double mass,
 			long position,
-			const std::vector<std::string>& neutralLosses) const;
+			const std::vector<NeutralLossPair>& neutralLosses) const;
 			
 		virtual double fixMass(double mass) const;
 };
@@ -182,7 +184,7 @@ class PrecursorIonGenerator : public IonGenerator
 		Ions generate(
 			const std::vector<double>& masses,
 			long charge,
-			const std::vector<std::string>& neutralLosses,
+			const std::vector<NeutralLossPair>& neutralLosses,
 			bool radical,
 			const std::string& sequence) const override;
 		
@@ -204,7 +206,7 @@ class PrecursorIonGenerator : public IonGenerator
 			Ions& ions,
 			double mass,
 			long position,
-			const std::vector<std::string>& neutralLosses) const override;
+			const std::vector<NeutralLossPair>& neutralLosses) const override;
 			
 		double fixMass(double mass) const override;
 };
@@ -213,13 +215,13 @@ void chargeIons(const Ions& sourceIons, Ions& target, long chargeState);
 
 inline Ion generateNeutralLossIon(
 	const std::string& typeChar,
-	const std::string& neutralLoss,
+	const NeutralLossPair neutralLoss,
 	double mass,
 	long position)
 {
 	return {
-		mass - FIXED_MASSES.at(neutralLoss),
-		"[" + typeChar + std::to_string(position + 1) + "-" + neutralLoss + "][+]",
+		mass - neutralLoss.second,
+		"[" + typeChar + std::to_string(position + 1) + "-" + neutralLoss.first + "][+]",
 		position + 1
 	};
 }

--- a/tests/test_pepfrag.py
+++ b/tests/test_pepfrag.py
@@ -130,6 +130,58 @@ class TestPeptideFragmentation(unittest.TestCase):
         with self.assertRaisesRegex(KeyError, r'Invalid residue detected: U'):
             peptide.fragment()
 
+    def test_neutral_losses(self):
+        peptide = Peptide('AAAK', 2, [])
+        peptide.fragment(ion_types={
+            IonType.b.value: ['NH3', ('testLoss', 9.)],
+            IonType.precursor.value: ['CO2', ('testLoss2', 13.)],
+            IonType.imm.value: [('testLoss3', 2.04), 'H2O']
+        })
+
+        expected_ions = {
+            (44.049475632459, 'imm(A)', 0),
+             (42.009475632459, '[imm1-testLoss3][+]', 1),
+             (26.038910948429, '[imm1-H2O][+]', 1),
+             (42.009475632459, '[imm2-testLoss3][+]', 2),
+             (26.038910948429, '[imm2-H2O][+]', 2),
+             (42.009475632459, '[imm3-testLoss3][+]', 3),
+             (26.038910948429, '[imm3-H2O][+]', 3),
+             (101.107324862499, 'imm(K)', 0),
+             (72.044390252029, 'b1[+]', 1),
+             (55.01784115090901, '[b1-NH3][+]', 1),
+             (63.044390252029004, '[b1-testLoss][+]', 1),
+             (143.081504037179, 'b2[+]', 2),
+             (126.054954936059, '[b2-NH3][+]', 2),
+             (134.081504037179, '[b2-testLoss][+]', 2),
+             (214.118617822329, 'b3[+]', 3),
+             (197.09206872120902, '[b3-NH3][+]', 3),
+             (205.118617822329, '[b3-testLoss][+]', 3),
+             (107.56294714460401, 'b3[2+]', 3),
+             (99.04967259404401, '[b3-NH3][2+]', 3),
+             (103.06294714460401, '[b3-testLoss][2+]', 3),
+             (99.06732486249899, '[imm4-testLoss3][+]', 4),
+             (83.096760178469, '[imm4-H2O][+]', 4),
+             (21.508376049669, '[imm3-testLoss3][2+]', 3),
+             (13.523093707653999, '[imm3-H2O][2+]', 3),
+             (360.22414552154896, '[M+H][+]', 4),
+             (316.234315521549, '[M-CO2][+]', 4),
+             (347.22414552154896, '[M-testLoss2][+]', 4),
+             (180.615710994214, '[M+H][2+]', 4),
+             (158.620795994214, '[M-CO2][2+]', 4),
+             (174.115710994214, '[M-testLoss2][2+]', 4),
+             (50.037300664689, '[imm4-testLoss3][2+]', 4),
+             (42.052018322674, '[imm4-H2O][2+]', 4)
+        }
+
+        self.assertEqual(expected_ions, set(peptide.fragment_ions))
+
+    def test_unknown_string_neutral_loss(self):
+        peptide = Peptide('AAAK', 2, [])
+        with self.assertRaises(KeyError):
+            peptide.fragment(ion_types={
+                IonType.b.value: ['test']
+            })
+
     def test_radical(self):
         peptide = Peptide('AAA', 2, [], radical=True)
         peptide.fragment(ion_types={


### PR DESCRIPTION
The neutral loss interface has been changed so that losses are specified as a tuple of their string name and mass. If the loss is standard and part of pepfrag, then the string alone is sufficient.